### PR TITLE
Add Userlist as an additional provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Courrier supports these transactional email providers:
 - [Postmark](https://postmarkapp.com)
 - [SendGrid](https://sendgrid.com)
 - [SparkPost](https://sparkpost.com)
+- [Userlist](https://userlist.com)
 
 ⚠️ Some providers still need manual verification of their implementation. If you're using one of these providers, please help verify the implementation by sharing your experience in [this GitHub issue](https://github.com/Rails-Designer/courrier/issues/4). 🙏
 

--- a/lib/courrier/email/provider.rb
+++ b/lib/courrier/email/provider.rb
@@ -10,6 +10,7 @@ require "courrier/email/providers/postmark"
 require "courrier/email/providers/preview"
 require "courrier/email/providers/sendgrid"
 require "courrier/email/providers/sparkpost"
+require "courrier/email/providers/userlist"
 
 module Courrier
   class Email
@@ -43,7 +44,8 @@ module Courrier
         postmark: Courrier::Email::Providers::Postmark,
         preview: Courrier::Email::Providers::Preview,
         sendgrid: Courrier::Email::Providers::Sendgrid,
-        sparkpost: Courrier::Email::Providers::Sparkpost
+        sparkpost: Courrier::Email::Providers::Sparkpost,
+        userlist: Courrier::Email::Providers::Userlist
       }.freeze
 
       def configuration_missing_in_production?

--- a/lib/courrier/email/providers/userlist.rb
+++ b/lib/courrier/email/providers/userlist.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Courrier
+  class Email
+    module Providers
+      class Userlist < Base
+        ENDPOINT_URL = "https://push.userlist.com/messages"
+
+        def body
+          {
+            "from" => @options.from,
+            "to" => @options.to,
+            "subject" => @options.subject,
+            "body" => body_document,
+          }.compact.merge(provider_options)
+        end
+
+        private
+
+        def headers
+          {
+            "Authorization" => "Push #{@api_key}"
+          }
+        end
+
+        def body_document
+          if @options.html && @options.text
+            multipart_document
+          elsif @options.html
+            html_document
+          elsif @options.text
+            text_document
+          end
+        end
+
+        def text_document
+          {
+            "type" => "text",
+            "content" => @options.text,
+          }
+        end
+
+        def html_document
+          {
+            "type" => "html",
+            "content" => @options.html,
+          }
+        end
+
+        def multipart_document
+          {
+            "type" => "multipart",
+            "content" => [
+              html_document,
+              text_document
+            ]
+          }
+        end
+
+        def provider_options
+          { "theme" => nil }.merge(@provider_options)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds support for Userlist's recently released [Transactional Messages API](https://userlist.com/docs/developers/push-api/#messages). While some of attributes sent to the API in this implementation are not publicly documented (yet), they're available, stable, and already used [elsewhere](https://github.com/userlist/userlist-ruby/blob/main/lib/userlist/delivery_method.rb). 