### PR TITLE
Pass context_options as dataVariables for Loops provider

### DIFF
--- a/lib/courrier/email.rb
+++ b/lib/courrier/email.rb
@@ -79,7 +79,8 @@ module Courrier
         provider: @provider,
         api_key: @api_key,
         options: @options,
-        provider_options: Courrier.configuration&.providers&.[](@provider.to_s.downcase.to_sym)
+        provider_options: Courrier.configuration&.providers&.[](@provider.to_s.downcase.to_sym),
+        context_options: @context_options
       ).deliver
     end
     alias_method :deliver_now, :deliver

--- a/lib/courrier/email/provider.rb
+++ b/lib/courrier/email/provider.rb
@@ -16,11 +16,12 @@ require "courrier/email/providers/userlist"
 module Courrier
   class Email
     class Provider
-      def initialize(provider: nil, api_key: nil, options: {}, provider_options: {})
+      def initialize(provider: nil, api_key: nil, options: {}, provider_options: {}, context_options: {})
         @provider = provider
         @api_key = api_key
         @options = options
         @provider_options = provider_options
+        @context_options = context_options
       end
 
       def deliver
@@ -30,7 +31,8 @@ module Courrier
         provider_class.new(
           api_key: @api_key,
           options: @options,
-          provider_options: @provider_options
+          provider_options: @provider_options,
+          context_options: @context_options
         ).deliver
       end
 

--- a/lib/courrier/email/providers/base.rb
+++ b/lib/courrier/email/providers/base.rb
@@ -6,10 +6,11 @@ module Courrier
   class Email
     module Providers
       class Base
-        def initialize(api_key: nil, options: {}, provider_options: {})
+        def initialize(api_key: nil, options: {}, provider_options: {}, context_options: {})
           @api_key = api_key
           @options = options
           @provider_options = provider_options
+          @context_options = context_options
         end
 
         def deliver

--- a/lib/courrier/email/providers/loops.rb
+++ b/lib/courrier/email/providers/loops.rb
@@ -22,14 +22,7 @@ module Courrier
           }
         end
 
-        def data_variables
-          {
-            "from" => @options.from,
-            "subject" => @options.subject,
-            "text_content" => @options.text,
-            "html_content" => @options.html
-          }.compact
-        end
+        def data_variables = @context_options.compact
       end
     end
   end


### PR DESCRIPTION
Loops only works with templates from their app. You need to pass a dataVariables hash. 

With this PR, Courrier passes any (context) attribute along, eg. `OrderEmail.deliver to: "services@railsdesigner.com", teamName: "Rails Designer", accountId: "acc_1234"`