### PR TITLE
Skip email-suffix if present

### DIFF
--- a/lib/generators/courrier/email_generator.rb
+++ b/lib/generators/courrier/email_generator.rb
@@ -14,6 +14,8 @@ module Courrier
 
     private
 
+    def file_name = super.delete_suffix("_email")
+
     def parent_class = defined?(ApplicationEmail) ? ApplicationEmail : Courrier::Email
   end
 end


### PR DESCRIPTION
When writing `rails g courrier:email WelcomeEmail` it wont create a `app/emails/welcome_email_email.rb` 🤪