### PR TITLE
Include reply-to, cc + bcc in logging output

### DIFF
--- a/lib/courrier/email/providers/logger.rb
+++ b/lib/courrier/email/providers/logger.rb
@@ -21,9 +21,7 @@ module Courrier
           <<~EMAIL
             #{separator}
             Timestamp: #{Time.now.strftime("%Y-%m-%d %H:%M:%S %z")}
-            From:      #{@options.from}
-            To:        #{@options.to}
-            Subject:   #{@options.subject}
+            #{meta_fields(from: options)}
 
             Text:
             #{@options.text || "(empty)"}
@@ -35,6 +33,27 @@ module Courrier
         end
 
         def separator = "-" * 80
+
+        def meta_fields(from:)
+          fields = [
+            [:from, "From"],
+            [:to, "To"],
+            [:reply_to, "Reply-To"],
+            [:cc, "Cc"],
+            [:bcc, "Bcc"],
+            [:subject, "Subject"]
+          ]
+
+          fields.map do |field, label|
+            value = from.send(field)
+
+            next if value.nil? || value.to_s.strip.empty?
+
+            "#{label}:".ljust(11) + value
+          rescue NoMatchingPatternError
+            nil
+          end.compact.join("\n")
+        end
       end
     end
   end

--- a/test/courrier/email/providers/logger_test.rb
+++ b/test/courrier/email/providers/logger_test.rb
@@ -7,7 +7,8 @@ module Courrier::Email::Providers
     def test_formats_email_for_logging
       email = TestEmail.new(
         from: "devs@railsdesigner.com",
-        to: "recipient@railsdesigner.com"
+        to: "recipient@railsdesigner.com",
+        reply_to: "support@railsdesigner.com"
       )
       logger = Logger.new(options: email.options)
 
@@ -18,6 +19,23 @@ module Courrier::Email::Providers
       assert_includes output, "Subject:   Test Subject"
       assert_includes output, "Text:\nTest Body"
       assert_includes output, "HTML:\n<p>Test HTML Body</p>"
+    end
+
+    def test_formats_optional_meta_fields_for_logging
+      email = TestEmail.new(
+        from: "devs@chirpform.com",
+        to: "recipient@chirpform.com",
+        reply_to: "reply-to@chirpform.com",
+        cc: "cc@chirpform.com",
+        bcc: "bcc@chirpform.com"
+      )
+      logger = Logger.new(options: email.options)
+
+      output = capture_logger_output { logger.deliver }
+
+      assert_includes output, "Reply-To:  reply-to@chirpform.com"
+      assert_includes output, "Cc:        cc@chirpform.com"
+      assert_includes output, "Bcc:       bcc@chirpform.com"
     end
 
     private


### PR DESCRIPTION
Something like this:

```bash
10:44:39 web.1  | --------------------------------------------------------------------------------
10:44:39 web.1  | Timestamp: 2025-11-13 10:44:39 +0700
10:44:39 web.1  | From:      Chirp Form Team <support@notifications.chirpform.com>
10:44:39 web.1  | To:        eelco@example.com
10:44:39 web.1  | Reply-To:  support@chirpform.com
10:44:39 web.1  | Subject:   Welcome to Chirp Form! 🐦
```