### PR TITLE
Updated `bin/release`

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -3,17 +3,32 @@
 VERSION=$1
 
 if [ -z "$VERSION" ]; then
-  echo "Error: The version number is required."
-  echo "Usage: $0 <version-number>"
+  echo "Error: Version number or bump type is required."
+  echo "Usage: $0 <major|minor|patch|version-number>"
+
   exit 1
 fi
 
+if [[ "$VERSION" =~ ^(major|minor|patch)$ ]]; then
+  CURRENT=$(grep -o '"[^"]*"' ./lib/courrier/version.rb | tr -d '"')
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+  case $VERSION in
+    major) VERSION="$((MAJOR + 1)).0.0" ;;
+    minor) VERSION="$MAJOR.$((MINOR + 1)).0" ;;
+    patch) VERSION="$MAJOR.$MINOR.$((PATCH + 1))" ;;
+  esac
+fi
+
 printf "module Courrier\n  VERSION = \"$VERSION\"\nend\n" > ./lib/courrier/version.rb
+
 bundle
+
 git add Gemfile.lock lib/courrier/version.rb
 git commit -m "Bump version for $VERSION"
 git push
 git tag v$VERSION
 git push --tags
-gem build courrier.gemspec
-gem push "courrier-$VERSION.gem"
+
+bundle exec rake build
+gem push "pkg/courrier-$VERSION.gem"


### PR DESCRIPTION
This allows to push a new release via `bin/release {major,minor,patch}` which is easier than looking up what the current version is. 🦥