### PR TITLE
Add support for markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,53 @@ end
 ```
 
 
+## Markdown support
+
+Courrier supports rendering markdown content to HTML when a markdown gem is available. Simply bundle any supported markdown gem (`redcarpet`, `kramdown` or `commonmarker`) and it will be used.
+
+
+### Markdown methods
+
+Define a `markdown` method in your email class:
+```ruby
+class OrderEmail < Courrier::Email
+  def subject = "Your order is ready!"
+
+  def markdown
+    <<~MARKDOWN
+      # Hello #{name}!
+
+      Your order **##{order_id}** is ready for pickup.
+
+      ## Order Details
+      - Item: #{item_name}
+      - Price: #{price}
+    MARKDOWN
+  end
+end
+```
+
+
+### Markdown templates
+
+Create markdown template files alongside your email class:
+- `app/emails/order_email.md.erb`
+- `app/emails/order_email.markdown.erb`
+
+```erb
+<!-- app/emails/order_email.md.erb -->
+# Hello <%= name %>!
+
+Your order **#<%= order_id %>** is ready for pickup.
+
+## Order Details
+- Item: <%= item_name %>
+- Price: <%= price %>
+```
+
+Method definitions take precedence over template files. You can mix approaches. For example, define `text` in a method and use a markdown template for HTML content.
+
+
 ### Auto-generate text from HTML
 
 Automatically generate plain text versions from your HTML emails:

--- a/lib/courrier/email.rb
+++ b/lib/courrier/email.rb
@@ -5,6 +5,7 @@ require "erb"
 require "courrier/email/address"
 require "courrier/jobs/email_delivery_job" if defined?(Rails)
 require "courrier/email/layouts"
+require "courrier/markdown"
 require "courrier/email/options"
 require "courrier/email/provider"
 
@@ -137,7 +138,9 @@ module Courrier
 
     def method_missing(name, *)
       if name == :text || name == :html
-        render_template(name.to_s)
+        render_template(name.to_s).tap do |result|
+          return result || markdown_rendered if name == :html
+        end
       else
         @context_options[name]
       end
@@ -147,6 +150,23 @@ module Courrier
       template_path = template_file_path(format)
 
       File.exist?(template_path) ? ERB.new(File.read(template_path)).result(binding) : nil
+    end
+
+    def render_markdown_template
+      %w[md markdown].each do |ext|
+        template_path = template_file_path(ext)
+
+        return ERB.new(File.read(template_path)).result(binding) if File.exist?(template_path)
+      end
+
+      nil
+    end
+
+    def markdown_rendered
+      return unless Courrier::Markdown.available?
+
+      markdown_content = render_markdown_template || (respond_to?(:markdown, true) ? markdown : nil)
+      Courrier::Markdown.render(markdown_content) if markdown_content
     end
 
     def template_file_path(format)

--- a/lib/courrier/markdown.rb
+++ b/lib/courrier/markdown.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Courrier
+  class Markdown
+    class << self
+      def available?
+        defined?(::Redcarpet) || defined?(::Kramdown) || defined?(::Commonmarker)
+      end
+
+      def render(text)
+        return unless available?
+
+        parser.parse(text.to_s)
+      end
+
+      private
+
+      def parser
+        @parser ||= available_parser.new
+      end
+
+      def available_parser
+        return RedcarpetParser if defined?(::Redcarpet)
+        return KramdownParser if defined?(::Kramdown)
+        return CommonmarkerParser if defined?(::Commonmarker)
+
+        Parser
+      end
+    end
+
+    class Parser
+      def parse(text) = text.to_s
+    end
+
+    class RedcarpetParser < Parser
+      def parse(text)
+        renderer = Redcarpet::Render::HTML.new
+        markdown = Redcarpet::Markdown.new(renderer)
+
+        markdown.render(text)
+      end
+    end
+
+    class KramdownParser < Parser
+      def parse(text) = Kramdown::Document.new(text).to_html
+    end
+
+    class CommonmarkerParser < Parser
+      def parse(text) = Commonmarker.to_html(text)
+    end
+  end
+end

--- a/test/courrier/email_test.rb
+++ b/test/courrier/email_test.rb
@@ -38,9 +38,7 @@ class Courrier::EmailTest < Minitest::Test
     email = Courrier::Email.new(from: "devs@railsdesigner.com", to: "recipient@railsdesigner.com")
 
     assert_nil email.subject
-
     assert_nil email.text
-
     assert_nil email.html
   end
 
@@ -100,48 +98,98 @@ class Courrier::EmailTest < Minitest::Test
   end
 
   def test_template_rendering_with_files
-  email_path = "tmp/test_emails"
+    email_path = "tmp/test_emails"
 
-  FileUtils.mkdir_p(email_path)
-  File.write("#{email_path}/test_email_with_templates.text.erb", "Hello <%= name %>!")
-  File.write("#{email_path}/test_email_with_templates.html.erb", "<p>Hello <strong><%= name %></strong>!</p>")
+    FileUtils.mkdir_p(email_path)
+    File.write("#{email_path}/test_email_with_templates.text.erb", "Hello <%= name %>!")
+    File.write("#{email_path}/test_email_with_templates.html.erb", "<p>Hello <strong><%= name %></strong>!</p>")
 
-  Courrier.configure do |config|
-    config.email_path = email_path
+    Courrier.configure do |config|
+      config.email_path = email_path
+    end
+
+    email = TestEmailWithTemplates.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      name: "World"
+    )
+
+    assert_equal "Hello World!", email.text
+    assert_equal "<p>Hello <strong>World</strong>!</p>", email.html
+
+    FileUtils.rm_rf(email_path)
   end
 
-  email = TestEmailWithTemplates.new(
-    to: "recipient@railsdesigner.com",
-    from: "devs@railsdesigner.com",
-    name: "World"
-  )
+  def test_method_takes_precedence_over_template
+    email_path = "tmp/test_emails"
 
-  assert_equal "Hello World!", email.text
-  assert_equal "<p>Hello <strong>World</strong>!</p>", email.html
+    FileUtils.mkdir_p(email_path)
+    File.write("#{email_path}/test_email_with_mixed_content.text.erb", "Template text")
+    File.write("#{email_path}/test_email_with_mixed_content.html.erb", "<p>Template HTML</p>")
 
-  FileUtils.rm_rf(email_path)
-end
+    Courrier.configure do |config|
+      config.email_path = email_path
+    end
 
-def test_method_takes_precedence_over_template
-  email_path = "tmp/test_emails"
+    email = TestEmailWithMixedContent.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com"
+    )
 
-  FileUtils.mkdir_p(email_path)
-  File.write("#{email_path}/test_email_with_mixed_content.text.erb", "Template text")
-  File.write("#{email_path}/test_email_with_mixed_content.html.erb", "<p>Template HTML</p>")
+    assert_equal "Method text", email.text
+    assert_equal "<p>Template HTML</p>", email.html
 
-  Courrier.configure do |config|
-    config.email_path = email_path
+    FileUtils.rm_rf(email_path)
   end
 
-  email = TestEmailWithMixedContent.new(
-    to: "recipient@railsdesigner.com",
-    from: "devs@railsdesigner.com"
-  )
+  def test_markdown_method_renders_when_gem_available
+    with_mocked_markdown do
+      email = EmailWithMarkdown.new(
+        to: "recipient@railsdesigner.com",
+        from: "devs@railsdesigner.com",
+        name: "World"
+      )
 
-  assert_equal "Method text", email.text
-  assert_equal "<p>Template HTML</p>", email.html
+      expected = "<p># Hello World!\n\nOrder **123** is ready.\n</p>"
+      assert_equal expected, email.html
+    end
+  end
 
-  FileUtils.rm_rf(email_path)
-end
+  def test_markdown_template_renders_when_gem_available
+    with_mocked_markdown do
+      email_path = "tmp/test_emails"
 
+      FileUtils.mkdir_p(email_path)
+      File.write("#{email_path}/email_with_markdown_template.md.erb", "Hello <%= name %>!")
+
+      Courrier.configure do |config|
+        config.email_path = email_path
+      end
+
+      email = EmailWithMarkdownTemplate.new(
+        to: "recipient@railsdesigner.com",
+        from: "devs@railsdesigner.com",
+        name: "World"
+      )
+
+      assert_equal "<p>Hello World!</p>", email.html
+
+      FileUtils.rm_rf(email_path)
+    end
+  end
+
+  private
+
+  def with_mocked_markdown
+    original_available = Courrier::Markdown.method(:available?)
+    original_render = Courrier::Markdown.method(:render)
+
+    Courrier::Markdown.define_singleton_method(:available?) { true }
+    Courrier::Markdown.define_singleton_method(:render) { |text| "<p>#{text}</p>" }
+
+    yield
+  ensure
+    Courrier::Markdown.define_singleton_method(:available?, original_available)
+    Courrier::Markdown.define_singleton_method(:render, original_render)
+  end
 end

--- a/test/fixtures/email_with_markdown.rb
+++ b/test/fixtures/email_with_markdown.rb
@@ -1,0 +1,27 @@
+class EmailWithMarkdown < Courrier::Email
+  def subject = "Markdown Test"
+
+  def markdown
+    <<~MARKDOWN
+      # Hello #{name}!
+
+      Order **#{order_id || "123"}** is ready.
+    MARKDOWN
+  end
+end
+
+class EmailWithMarkdownTemplate < Courrier::Email
+  def subject = "Markdown Template Test"
+end
+
+class EmailWithHtmlAndMarkdown < Courrier::Email
+  def subject = "HTML vs Markdown Test"
+
+  def html = "<p>HTML method</p>"
+
+  def markdown
+    <<~MARKDOWN
+      # This should not be used
+    MARKDOWN
+  end
+end


### PR DESCRIPTION
- bundle any of the supported markdown gems. 
- define a markdown (instead of a html) method, or;
- add a template file like `app/emails/order_email.{md,markdown}.erb`

And write your emails in markdown instead of HTML ☺️ 