### PR TITLE
Add headers class method to email classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ OrderEmail.deliver to: "recipient@railsdesigner.com",\
 Provider and API key settings can be overridden using environment variables (`COURRIER_PROVIDER` and `COURRIER_API_KEY`) for both global configuration and email class defaults.
 
 
+## Custom headers
+
+Email classes can define custom HTTP headers that are sent with every email:
+```ruby
+class OrderEmail < Courrier::Email
+  headers list_unsubscribe_post: "List-Unsubscribe=One-Click"
+
+  def subject = "Rails Icons now supports SVG sprites!"
+
+  def text = # …
+  def markdown = # …
+end
+```
+
+Useful for adding provider-specific headers like List-Unsubscribe for Postmark, X-Mailer identifiers, or custom metadata headers required.
+
+
 ## Custom attributes
 
 Besides the standard email attributes (`from`, `to`, `reply_to`, etc.), you can pass any additional attributes that will be available in your email templates:

--- a/lib/courrier/email.rb
+++ b/lib/courrier/email.rb
@@ -37,7 +37,11 @@ module Courrier
         @queue_options ||= {}
       end
 
-      attr_writer :queue_options
+      attr_writer :queue_options, :headers
+
+      def headers(**options)
+        options.empty? ? (@headers ||= {}) : @headers = options
+      end
 
       def enqueue(**options)
         self.queue_options = options
@@ -101,7 +105,8 @@ module Courrier
         api_key: @api_key,
         options: @options,
         provider_options: Courrier.configuration&.providers&.[](@provider.to_s.downcase.to_sym),
-        context_options: @context_options
+        context_options: @context_options,
+        custom_headers: self.class.headers
       ).deliver
     end
     alias_method :deliver_now, :deliver

--- a/lib/courrier/email/provider.rb
+++ b/lib/courrier/email/provider.rb
@@ -30,13 +30,14 @@ module Courrier
         userlist: Courrier::Email::Providers::Userlist
       }
 
-      def initialize(provider: nil, api_key: nil, options: {}, provider_options: {}, context_options: {})
+      def initialize(provider: nil, api_key: nil, options: {}, provider_options: {}, context_options: {}, custom_headers: {})
         @provider = provider
         @api_key = api_key
 
         @options = options
         @provider_options = provider_options
         @context_options = context_options
+        @custom_headers = custom_headers
       end
 
       def deliver
@@ -47,7 +48,8 @@ module Courrier
           api_key: @api_key,
           options: @options,
           provider_options: @provider_options,
-          context_options: @context_options
+          context_options: @context_options,
+          custom_headers: @custom_headers
         ).deliver
       end
 

--- a/lib/courrier/email/providers/base.rb
+++ b/lib/courrier/email/providers/base.rb
@@ -6,11 +6,12 @@ module Courrier
   class Email
     module Providers
       class Base
-        def initialize(api_key: nil, options: {}, provider_options: {}, context_options: {})
+        def initialize(api_key: nil, options: {}, provider_options: {}, context_options: {}, custom_headers: {})
           @api_key = api_key
           @options = options
           @provider_options = provider_options
           @context_options = context_options
+          @custom_headers = custom_headers
         end
 
         def deliver
@@ -31,7 +32,11 @@ module Courrier
 
         def content_type = "application/json"
 
-        def headers = {}
+        def headers
+          default_headers.merge(@custom_headers)
+        end
+
+        def default_headers = {}
 
         def provider = self.class.name.split("::").last
       end

--- a/lib/courrier/email/providers/loops.rb
+++ b/lib/courrier/email/providers/loops.rb
@@ -16,7 +16,7 @@ module Courrier
 
         private
 
-        def headers
+        def default_headers
           {
             "Authorization" => "Bearer #{@api_key}"
           }

--- a/lib/courrier/email/providers/mailgun.rb
+++ b/lib/courrier/email/providers/mailgun.rb
@@ -29,7 +29,7 @@ module Courrier
 
         def content_type = "multipart/form-data"
 
-        def headers
+        def default_headers
           {
             "Authorization" => "Basic #{Base64.strict_encode64("api:#{@api_key}")}"
           }

--- a/lib/courrier/email/providers/mailjet.rb
+++ b/lib/courrier/email/providers/mailjet.rb
@@ -31,7 +31,7 @@ module Courrier
 
         private
 
-        def headers
+        def default_headers
           {
             "Authorization" => "Basic " + Base64.strict_encode64("#{@api_key}:#{@provider_options.api_secret}")
           }

--- a/lib/courrier/email/providers/mailpace.rb
+++ b/lib/courrier/email/providers/mailpace.rb
@@ -21,7 +21,7 @@ module Courrier
 
         private
 
-        def headers
+        def default_headers
           {
             "MailPace-Server-Token" => @api_key
           }

--- a/lib/courrier/email/providers/postmark.rb
+++ b/lib/courrier/email/providers/postmark.rb
@@ -23,7 +23,7 @@ module Courrier
 
         private
 
-        def headers
+        def default_headers
           {
             "X-Postmark-Server-Token" => @api_key
           }

--- a/lib/courrier/email/providers/resend.rb
+++ b/lib/courrier/email/providers/resend.rb
@@ -21,7 +21,7 @@ module Courrier
 
         private
 
-        def headers
+        def default_headers
           {
             "Authorization" => "Bearer #{@api_key}"
           }

--- a/lib/courrier/email/providers/sendgrid.rb
+++ b/lib/courrier/email/providers/sendgrid.rb
@@ -38,7 +38,7 @@ module Courrier
 
         private
 
-        def headers
+        def default_headers
           {
             "Authorization" => "Bearer #{@api_key}"
           }

--- a/lib/courrier/email/providers/sparkpost.rb
+++ b/lib/courrier/email/providers/sparkpost.rb
@@ -27,7 +27,7 @@ module Courrier
 
         private
 
-        def headers
+        def default_headers
           {
             "Authorization" => @api_key
           }

--- a/lib/courrier/email/providers/userlist.rb
+++ b/lib/courrier/email/providers/userlist.rb
@@ -17,7 +17,7 @@ module Courrier
 
         private
 
-        def headers
+        def default_headers
           {
             "Authorization" => "Push #{@api_key}"
           }

--- a/test/courrier/email_test.rb
+++ b/test/courrier/email_test.rb
@@ -184,11 +184,19 @@ class Courrier::EmailTest < Minitest::Test
     original_available = Courrier::Markdown.method(:available?)
     original_render = Courrier::Markdown.method(:render)
 
+    class << Courrier::Markdown
+      remove_method(:available?)
+      remove_method(:render)
+    end
     Courrier::Markdown.define_singleton_method(:available?) { true }
     Courrier::Markdown.define_singleton_method(:render) { |text| "<p>#{text}</p>" }
 
     yield
   ensure
+    class << Courrier::Markdown
+      remove_method(:available?)
+      remove_method(:render)
+    end
     Courrier::Markdown.define_singleton_method(:available?, original_available)
     Courrier::Markdown.define_singleton_method(:render, original_render)
   end

--- a/test/courrier/providers/base_test.rb
+++ b/test/courrier/providers/base_test.rb
@@ -44,4 +44,28 @@ class Courrier::Email::Providers::BaseTest < Minitest::Test
       assert_instance_of Courrier::Email::Result, result
     end
   end
+
+  def test_headers_merges_custom_headers_with_default_headers
+    provider = Courrier::Email::Providers::TestProvider.new(
+      api_key: "test_key",
+      options: {},
+      custom_headers: {"foo_bar" => "baz", "Authorization" => "override"}
+    )
+
+    headers = provider.send(:headers)
+
+    assert_equal "baz", headers["foo_bar"]
+    assert_equal "override", headers["Authorization"]
+  end
+
+  def test_headers_returns_only_default_headers_when_no_custom_headers
+    provider = Courrier::Email::Providers::TestProvider.new(
+      api_key: "test_key",
+      options: {}
+    )
+
+    headers = provider.send(:headers)
+
+    assert_equal({}, headers)
+  end
 end


### PR DESCRIPTION
Allow email classes to define custom HTTP headers that are sent with every email:
```ruby
class OrderEmail < Courrier::Email
  headers list_unsubscribe_post: "List-Unsubscribe=One-Click"

  def subject = "Rails Icons now supports SVG sprites!"

  def text = # …
  def markdown = # …
end
```

Useful for adding provider-specific headers like `List-Unsubscribe` for Postmark, `X-Mailer` identifiers or custom metadata headers required.

Closes https://github.com/Rails-Designer/courrier/issues/14