### PR TITLE
Fix missing context_options in deliver_later (#22)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,6 @@ group :development, :test do
   gem "rake", "~> 13.2", ">= 13.2.1"
   gem "minitest", "~> 5.25", ">= 5.25.5"
   gem "debug", "~> 1.9", ">= 1.9.2"
+  gem "activejob", ">= 7.0"
+  gem "activesupport", ">= 7.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,40 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    activejob (8.1.3)
+      activesupport (= 8.1.3)
+      globalid (>= 0.3.6)
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
     childprocess (5.1.0)
       logger (~> 1.5)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    drb (2.2.3)
+    globalid (1.3.0)
+      activesupport (>= 6.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -31,11 +56,11 @@ GEM
     lint_roller (1.1.0)
     logger (1.7.0)
     minitest (5.25.5)
-    nokogiri (1.18.8-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.8.0)
@@ -48,7 +73,7 @@ GEM
     psych (5.2.3)
       date
       stringio
-    public_suffix (6.0.2)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -76,6 +101,7 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
     standard (1.49.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -89,16 +115,22 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
     stringio (3.1.7)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.1.1)
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
+  activejob (>= 7.0)
+  activesupport (>= 7.0)
   courrier!
   debug (~> 1.9, >= 1.9.2)
   minitest (~> 5.25, >= 5.25.5)

--- a/lib/courrier/email.rb
+++ b/lib/courrier/email.rb
@@ -123,7 +123,7 @@ module Courrier
         provider: @provider,
         api_key: @api_key,
         options: @options.to_h,
-        provider_options: Courrier.configuration&.providers&.[](@provider.to_s.downcase.to_sym),
+        provider_options: Courrier.configuration&.providers&.[](@provider.to_s.downcase.to_sym)&.to_h,
         context_options: @context_options
       }
 

--- a/lib/courrier/jobs/email_delivery_job.rb
+++ b/lib/courrier/jobs/email_delivery_job.rb
@@ -15,7 +15,7 @@ module Courrier
           cc: data[:options][:cc],
           bcc: data[:options][:bcc],
           provider_options: data[:provider_options],
-          context_options: data[:context_options]
+          **(data[:context_options] || {})
         ).deliver_now
       end
     end

--- a/test/courrier/email/provider_test.rb
+++ b/test/courrier/email/provider_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "courrier/email/provider"
 
 class TestCourrierEmailProvider < Minitest::Test
-  def setup
+  def teardown
     Object.send(:remove_const, :Rails) if defined?(Rails)
   end
 

--- a/test/courrier/jobs/email_delivery_job_test.rb
+++ b/test/courrier/jobs/email_delivery_job_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+# `Courrier::Jobs::EmailDeliveryJob` is only required when `Rails` is defined
+# (see lib/courrier/email.rb), so load ActiveJob (which the job inherits from)
+# and the ActiveSupport core extension that provides `String#constantize` to
+# allow the job class to load and run in isolation without all of Rails.
+require "active_job"
+require "active_support/core_ext/string/inflections"
+require "courrier/jobs/email_delivery_job"
+
+class Courrier::Jobs::EmailDeliveryJobTest < Minitest::Test
+  include TestEmailHelpers
+
+  def setup
+    reset_configuration
+  end
+
+  def test_perform_preserves_context_options_for_template_rendering
+    data = {
+      email_class: "TestEmailWithContext",
+      provider: "logger",
+      api_key: nil,
+      options: {
+        from: "devs@railsdesigner.com",
+        to: "recipient@railsdesigner.com"
+      },
+      provider_options: nil,
+      context_options: {order_id: "42", token: "abc"}
+    }
+
+    options_captured = nil
+    mock_provider = create_mock_provider
+
+    Courrier::Email::Provider.stub :new, ->(options) { options_captured = options; mock_provider } do
+      Courrier::Jobs::EmailDeliveryJob.new.perform(data)
+    end
+
+    assert_equal "Order 42", options_captured[:options].subject
+    assert_equal "Test order 42 with token abc", options_captured[:options].text
+  end
+
+  def test_deliver_later_data_is_active_job_serializable
+    require "active_job"
+    Courrier.configure do |config|
+      config.email = {provider: "logger"}
+      config.providers.logger.foo = "bar"
+    end
+
+    email = TestEmail.new(
+      from: "devs@railsdesigner.com",
+      to: "recipient@railsdesigner.com"
+    )
+
+    captured = nil
+    stub_perform_later = ->(data) { captured = data }
+
+    Courrier::Jobs::EmailDeliveryJob.stub :perform_later, stub_perform_later do
+      email.deliver_later
+    end
+
+    # ActiveJob's argument serializer raises SerializationError on any
+    # non-primitive value -- this asserts every value in `data` is serializable.
+    ActiveJob::Arguments.serialize([captured])
+  end
+
+  def test_perform_handles_nil_context_options
+    data = {
+      email_class: "TestEmail",
+      provider: "logger",
+      api_key: nil,
+      options: {
+        from: "devs@railsdesigner.com",
+        to: "recipient@railsdesigner.com"
+      },
+      provider_options: nil,
+      context_options: nil
+    }
+
+    mock_provider = create_mock_provider
+
+    Courrier::Email::Provider.stub :new, ->(_) { mock_provider } do
+      assert_equal "delivery_result", Courrier::Jobs::EmailDeliveryJob.new.perform(data)
+    end
+  end
+end


### PR DESCRIPTION
`EmailDeliveryJob#perform` was passing the original instance's `@context_options` as a single `context_options:` keyword to `email_class.new(...)`, but the constructor's `options.except(...)` list does not include `:context_options` -- so on the round-trip the context ended up nested inside itself:

```ruby
    @context_options = { context_options: { order_id: "42" }, ... }
```

In `method_missing(:order_id)` `@context_options[:order_id]` is read but nil, so subject/text rendering and any other access to custom attributes broke after `deliver_later`.

Spreading `**data[:context_options]` at the call site puts the keys at the level the constructor already handles, matching the existing `data[:options][:from/to/...]` pattern used in the same method.

I added a regression test that drives EmailDeliveryJob#perform directly (bypassing ActiveJob's enqueuing) and asserts the email body is rendered with the context values. I decided to add `activejob` and `activesupport` as dev/test dependencies so the job class, which inherits from `ActiveJob::Base` and uses `String#constantize`, can load without pulling in all of Rails.

As an aside, the existing suite seems to be flaky on some seeds due to `test/courrier/email/provider_test.rb` stubbing Rails and the constant leaks across tests. Confirmed by running --seed=1 on unchanged main (34 errors). Fixing this is out of scope for this PR, but if you would like I'd be happy to address it.