### PR TITLE
Add Brevo email and subscriber providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ end
 Courrier supports these transactional email providers:
 
 - [AWS SES](https://aws.amazon.com/ses/) — requires `aws-sigv4` gem
+- [Brevo](https://www.brevo.com/)
 - [Cloudflare Email Service](https://developers.cloudflare.com/email-service/)
 - [Lettermint](https://lettermint.co)
 - [Loops](https://loops.so)
@@ -494,6 +495,7 @@ end
 ### Supported providers
 
 - [Beehiiv](https://www.beehiiv.com/) - requires `publication_id`
+- [Brevo](https://www.brevo.com/) - accepts optional `list_ids`
 - [Buttondown](https://buttondown.com)
 - [Kit](https://kit.com/) (formerly ConvertKit) - requires `form_id`
 - [Loops](https://loops.so/)
@@ -510,6 +512,14 @@ config.subscriber = {
 }
 ```
 
+For Brevo, pass one or more list IDs when new contacts should be added to specific lists:
+```ruby
+config.subscriber = {
+  provider: "brevo",
+  api_key: "your_api_key",
+  list_ids: [12, 34]
+}
+```
 
 ### Custom providers
 

--- a/lib/courrier/email/provider.rb
+++ b/lib/courrier/email/provider.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "courrier/email/providers/base"
+require "courrier/email/providers/brevo"
 require "courrier/email/providers/cloudflare"
 require "courrier/email/providers/lettermint"
 require "courrier/email/providers/logger"
@@ -20,6 +21,7 @@ module Courrier
   class Email
     class Provider
       PROVIDERS = {
+        brevo: Courrier::Email::Providers::Brevo,
         cloudflare: Courrier::Email::Providers::Cloudflare,
         logger: Courrier::Email::Providers::Logger,
         lettermint: Courrier::Email::Providers::Lettermint,

--- a/lib/courrier/email/providers/brevo.rb
+++ b/lib/courrier/email/providers/brevo.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Courrier
+  class Email
+    module Providers
+      class Brevo < Base
+        ENDPOINT_URL = "https://api.brevo.com/v3/smtp/email"
+
+        def body
+          {
+            "sender" => email_address(@options.from),
+            "to" => email_addresses(@options.to),
+            "cc" => email_addresses(@options.cc),
+            "bcc" => email_addresses(@options.bcc),
+            "replyTo" => email_address(@options.reply_to),
+            "subject" => @options.subject,
+            "htmlContent" => @options.html,
+            "textContent" => @options.text
+          }.compact
+        end
+
+        private
+
+        def default_headers = {"api-key" => @api_key}
+
+        def email_addresses(addresses)
+          addresses&.split(",")&.map { |address| email_address(address) }
+        end
+
+        def email_address(address)
+          {"email" => address.strip} if address
+        end
+      end
+    end
+  end
+end

--- a/lib/courrier/subscriber/brevo.rb
+++ b/lib/courrier/subscriber/brevo.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "uri"
+require "courrier/subscriber/base"
+
+module Courrier
+  class Subscriber
+    class Brevo < Base
+      ENDPOINT_URL = "https://api.brevo.com/v3/contacts"
+
+      def create(email)
+        body = {
+          "email" => email,
+          "updateEnabled" => true
+        }
+
+        list_ids = Array(Courrier.configuration.subscriber[:list_ids]).compact
+        body["listIds"] = list_ids unless list_ids.empty?
+
+        request(:post, ENDPOINT_URL, body)
+      end
+
+      def destroy(email)
+        identifier = URI.encode_www_form_component(email)
+
+        request(:delete, "#{ENDPOINT_URL}/#{identifier}")
+      end
+
+      private
+
+      def headers
+        {
+          "api-key" => @api_key,
+          "Content-Type" => "application/json"
+        }
+      end
+    end
+  end
+end

--- a/test/courrier/email/providers/brevo_test.rb
+++ b/test/courrier/email/providers/brevo_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+module Courrier::Email::Providers
+  class BrevoTest < Minitest::Test
+    def setup
+      email = TestEmail.new(
+        from: "devs@railsdesigner.com",
+        to: "first@example.com, second@example.com",
+        reply_to: "support@railsdesigner.com",
+        cc: "copy@example.com",
+        bcc: "archive@example.com"
+      )
+
+      @provider = Brevo.new(api_key: "test_key", options: email.options)
+    end
+
+    def test_formats_transactional_email
+      assert_equal(
+        {
+          "sender" => {"email" => "devs@railsdesigner.com"},
+          "to" => [{"email" => "first@example.com"}, {"email" => "second@example.com"}],
+          "cc" => [{"email" => "copy@example.com"}],
+          "bcc" => [{"email" => "archive@example.com"}],
+          "replyTo" => {"email" => "support@railsdesigner.com"},
+          "subject" => "Test Subject",
+          "htmlContent" => "<p>Test HTML Body</p>",
+          "textContent" => "Test Body"
+        },
+        @provider.body
+      )
+    end
+
+    def test_authenticates_with_api_key
+      assert_equal({"api-key" => "test_key"}, @provider.send(:default_headers))
+    end
+
+    def test_is_available_through_provider_registry
+      mock_provider = Minitest::Mock.new
+      mock_provider.expect(:deliver, nil)
+
+      Brevo.stub :new, mock_provider do
+        Courrier::Email::Provider.new(
+          provider: "brevo",
+          api_key: "test_key",
+          options: @provider.instance_variable_get(:@options)
+        ).deliver
+      end
+
+      mock_provider.verify
+    end
+  end
+end

--- a/test/courrier/subscriber/brevo_test.rb
+++ b/test/courrier/subscriber/brevo_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+require "courrier/subscriber/brevo"
+
+class Courrier::Subscriber::BrevoTest < Minitest::Test
+  def setup
+    Courrier.configure do |config|
+      config.subscriber = {
+        provider: :brevo,
+        api_key: "test_key",
+        list_ids: [12, 34]
+      }
+    end
+
+    @provider = Courrier::Subscriber::Brevo.new(api_key: "test_key")
+  end
+
+  def test_creates_contact_in_configured_lists
+    request = capture_request do
+      @provider.create("subscriber@example.com")
+    end
+
+    assert_equal :post, request[:method]
+    assert_equal "https://api.brevo.com/v3/contacts", request[:url]
+    assert_equal(
+      {
+        "email" => "subscriber@example.com",
+        "listIds" => [12, 34],
+        "updateEnabled" => true
+      },
+      request[:body]
+    )
+  end
+
+  def test_deletes_contact_by_email
+    request = capture_request do
+      @provider.destroy("subscriber+tag@example.com")
+    end
+
+    assert_equal :delete, request[:method]
+    assert_equal "https://api.brevo.com/v3/contacts/subscriber%2Btag%40example.com", request[:url]
+    assert_nil request[:body]
+  end
+
+  def test_authenticates_with_api_key
+    assert_equal(
+      {
+        "api-key" => "test_key",
+        "Content-Type" => "application/json"
+      },
+      @provider.send(:headers)
+    )
+  end
+
+  private
+
+  def capture_request
+    request = nil
+    result = Courrier::Subscriber::Result.new(response: Data.define(:code, :body).new(code: "200", body: "{}"))
+
+    request_handler = lambda do |method, url, body = nil|
+      request = {method: method, url: url, body: body}
+      result
+    end
+
+    @provider.stub :request, request_handler do
+      yield
+    end
+
+    request
+  end
+end


### PR DESCRIPTION
## Summary
- add Brevo transactional email delivery through `/v3/smtp/email`
- add Brevo contact create/delete support for newsletter subscribers
- support optional `list_ids` and idempotent contact updates
- register and document both provider integrations

## Why
Courrier supports several transactional and subscriber platforms, but Brevo users currently need custom provider classes for both email delivery and contact management.

## Tests
- `bundle exec ruby -Itest test/courrier/email/providers/brevo_test.rb`
- `bundle exec ruby -Itest test/courrier/subscriber/brevo_test.rb`
- `bundle exec ruby -Itest test/courrier/email/provider_test.rb`
- `bundle exec rake` (100 runs, 189 assertions)
- `bundle exec standardrb`
- `bundle exec standardrb` on all touched Ruby files, including tests
- `git diff --check`

Part of #35
