### PR TITLE
Support for Postmark templates API

### DIFF
--- a/lib/courrier/email/providers/postmark.rb
+++ b/lib/courrier/email/providers/postmark.rb
@@ -4,31 +4,64 @@ module Courrier
   class Email
     module Providers
       class Postmark < Base
-        def self.config_options = %w[message_stream]
+        def self.config_options = %w[message_stream template_alias template_id]
 
-        ENDPOINT_URL = "https://api.postmarkapp.com/email"
+        EMAIL_ENDPOINT = "https://api.postmarkapp.com/email"
+        TEMPLATE_ENDPOINT = "https://api.postmarkapp.com/email/withTemplate"
 
         def body
-          {
-            "From" => @options.from,
-
-            "To" => @options.to,
-            "ReplyTo" => @options.reply_to,
-
-            "Subject" => @options.subject,
-            "TextBody" => @options.text,
-            "HtmlBody" => @options.html,
-
-            "MessageStream" => @provider_options.message_stream || "outbound"
-          }.compact
+          template? ? template_body : standard_body
         end
 
         private
+
+        def endpoint_url
+          template? ? TEMPLATE_ENDPOINT : EMAIL_ENDPOINT
+        end
 
         def default_headers
           {
             "X-Postmark-Server-Token" => @api_key
           }
+        end
+
+        def standard_body
+          {
+            "From" => @options.from,
+            "To" => @options.to,
+            "ReplyTo" => @options.reply_to,
+            "Subject" => @options.subject,
+            "TextBody" => @options.text,
+            "HtmlBody" => @options.html,
+            "MessageStream" => @provider_options.message_stream || "outbound"
+          }.compact
+        end
+
+        def template_body
+          {
+            "From" => @options.from,
+            "To" => @options.to,
+            "Cc" => @options.cc,
+            "Bcc" => @options.bcc,
+            "ReplyTo" => @options.reply_to,
+            "TemplateId" => template_id,
+            "TemplateAlias" => template_alias,
+            "TemplateModel" => @context_options.except(:template_id, :template_alias).compact,
+            "MessageStream" => @provider_options.message_stream || "outbound"
+          }.compact
+        end
+
+        def template_id
+          @context_options[:template_id] || @provider_options.template_id
+        end
+
+        def template_alias
+          @context_options[:template_alias] || @provider_options.template_alias
+        end
+
+        def template?
+          !!(@context_options[:template_id] || @context_options[:template_alias] ||
+            @provider_options.template_id || @provider_options.template_alias)
         end
       end
     end

--- a/test/courrier/providers/postmark_test.rb
+++ b/test/courrier/providers/postmark_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class Courrier::Email::Providers::PostmarkTest < Minitest::Test
+  def setup
+    @provider = Courrier::Email::Providers::Postmark.new(
+      api_key: "test_key",
+      options: Courrier::Email::Options.new(
+        from: "devs@railsdesigner.com",
+        to: "recipient@railsdesigner.com",
+        subject: "Hello",
+        text: "Hello there",
+        html: "<p>Hello there</p>"
+      ),
+      provider_options: Courrier::Configuration::ProviderConfig.new,
+      context_options: {}
+    )
+  end
+
+  def test_standard_body_uses_email_endpoint
+    assert_equal "https://api.postmarkapp.com/email", @provider.send(:endpoint_url)
+    assert_equal "Hello", @provider.body["Subject"]
+    assert_equal "Hello there", @provider.body["TextBody"]
+    assert_nil @provider.body["TemplateId"]
+    assert_nil @provider.body["TemplateModel"]
+  end
+
+  def test_template_alias_via_context_options_uses_template_endpoint
+    @provider.instance_variable_set(:@context_options, {template_alias: "welcome", user_name: "John"})
+
+    assert_equal "https://api.postmarkapp.com/email/withTemplate", @provider.send(:endpoint_url)
+
+    body = @provider.body
+
+    assert_equal "welcome", body["TemplateAlias"]
+    assert_equal({user_name: "John"}, body["TemplateModel"])
+    assert_nil body["Subject"]
+    assert_nil body["TemplateId"]
+  end
+
+  def test_template_id_via_provider_options_uses_template_endpoint
+    provider_options = Courrier::Configuration::ProviderConfig.new
+    provider_options.template_id = 1234
+
+    @provider.instance_variable_set(:@provider_options, provider_options)
+
+    assert_equal "https://api.postmarkapp.com/email/withTemplate", @provider.send(:endpoint_url)
+
+    body = @provider.body
+
+    assert_equal 1234, body["TemplateId"]
+    assert_nil body["TemplateAlias"]
+  end
+
+  def test_template_model_excludes_template_keys
+    @provider.instance_variable_set(:@context_options, {template_alias: "welcome", user_name: "John", order_id: 42})
+
+    assert_equal({user_name: "John", order_id: 42}, @provider.body["TemplateModel"])
+  end
+
+  def test_template_model_compacts_nil_values
+    @provider.instance_variable_set(:@context_options, {template_alias: "welcome", user_name: nil, order_id: 42})
+
+    assert_equal({order_id: 42}, @provider.body["TemplateModel"])
+  end
+
+  def test_context_options_take_precedence_over_provider_options
+    provider_options = Courrier::Configuration::ProviderConfig.new
+    provider_options.template_alias = "global-alias"
+
+    @provider.instance_variable_set(:@provider_options, provider_options)
+    @provider.instance_variable_set(:@context_options, {template_alias: "local-alias"})
+
+    assert_equal "local-alias", @provider.body["TemplateAlias"]
+  end
+end


### PR DESCRIPTION
Postmark has an API endpoint that works with "hosted" templates. See https://postmarkapp.com/developer/api/templates-api

This change to the postmark provider checks for a template_{alias,id} to check what endpoint and payload to send over.

I'd reckon you write a general Email class, you can use: `Email.deliver to: "cam@example.com", template_alias: "welcome", name: "Cam", user_id: 42`

I am reluctant to add/merge this because many features (also for Rails Courrier) becomes useless.