### PR TITLE
Escape HTML with optional overrides

### DIFF
--- a/lib/courrier/context_value.rb
+++ b/lib/courrier/context_value.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "cgi"
+
+require "courrier/safe_string"
+
+module Courrier
+  class ContextValue
+    def initialize(value, escape:)
+      @value = value
+      @escape = escape
+    end
+
+    def to_s
+      @escape ? CGI.escapeHTML(@value.to_s) : @value.to_s
+    end
+
+    def html_safe
+      SafeString.new(@value.to_s)
+    end
+    alias_method :h, :html_safe
+
+    def method_missing(name, *arguments, &block)
+      result = @value.send(name, *arguments, &block)
+
+      result.is_a?(String) ? ContextValue.new(result, escape: @escape) : result
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      @value.respond_to?(name, include_private) || super
+    end
+  end
+end

--- a/lib/courrier/email.rb
+++ b/lib/courrier/email.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require "erb"
-
+require "courrier/email/rendering"
 require "courrier/email/address"
 require "courrier/email/layouts"
-require "courrier/markdown"
 require "courrier/email/options"
 require "courrier/email/provider"
 
 module Courrier
   class Email
+    include Rendering
+
     attr_accessor :provider, :api_key, :default_url_options, :options, :queue_options
 
     @queue_options = {}
@@ -97,7 +97,7 @@ module Courrier
           bcc: options[:bcc] || self.class.bcc || Courrier.configuration&.bcc,
           subject: subject,
           text: text,
-          html: html,
+          html: in_html_context { html },
           auto_generate_text: Courrier.configuration&.auto_generate_text,
           layouts: Courrier::Email::Layouts.new(self).build
         )
@@ -133,46 +133,5 @@ module Courrier
     def delivery_disabled?
       ENV["COURRIER_EMAIL_DISABLED"] == "true" || ENV["COURRIER_EMAIL_ENABLED"] == "false"
     end
-
-    def method_missing(name, *)
-      if name == :text || name == :html
-        render_template(name.to_s).tap do |result|
-          return result || markdown_rendered if name == :html
-        end
-      else
-        @context_options[name]
-      end
-    end
-
-    def render_template(format)
-      template_path = template_file_path(format)
-
-      File.exist?(template_path) ? ERB.new(File.read(template_path)).result(binding) : nil
-    end
-
-    def render_markdown_template
-      %w[md markdown].each do |ext|
-        template_path = template_file_path(ext)
-
-        return ERB.new(File.read(template_path)).result(binding) if File.exist?(template_path)
-      end
-
-      nil
-    end
-
-    def markdown_rendered
-      return unless Courrier::Markdown.available?
-
-      markdown_content = render_markdown_template || (respond_to?(:markdown, true) ? markdown : nil)
-      Courrier::Markdown.render(markdown_content) if markdown_content
-    end
-
-    def template_file_path(format)
-      class_path = self.class.name.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
-
-      File.join(Courrier.configuration&.email_path, "#{class_path}.#{format}.erb")
-    end
-
-    def respond_to_missing?(name, include_private = false) = true
   end
 end

--- a/lib/courrier/email/options.rb
+++ b/lib/courrier/email/options.rb
@@ -15,9 +15,9 @@ module Courrier
         @cc = options.fetch(:cc, nil)
         @bcc = options.fetch(:bcc, nil)
 
-        @subject = options.fetch(:subject, "")
-        @text = options.fetch(:text, "")
-        @html = options.fetch(:html, "")
+        @subject = options.fetch(:subject, "").to_s
+        @text = options.fetch(:text, "").to_s
+        @html = options.fetch(:html, "").to_s
 
         @auto_generate_text = options.fetch(:auto_generate_text, false)
 

--- a/lib/courrier/email/rendering.rb
+++ b/lib/courrier/email/rendering.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "erb"
+
+require "courrier/context_value"
+require "courrier/safe_string"
+require "courrier/markdown"
+
+module Courrier
+  class Email
+    module Rendering
+      private
+
+      def method_missing(name, *)
+        return in_html_context { render_template("html") || markdown_rendered } if name == :html
+        return render_template("text") if name == :text
+
+        value = @context_options[name]
+        return value if value.is_a?(SafeString)
+
+        value.is_a?(String) ? ContextValue.new(value, escape: @html_context) : value
+      end
+
+      def in_html_context
+        previous = @html_context
+        @html_context = true
+
+        yield
+      ensure
+        @html_context = previous
+      end
+
+      def in_safe_context
+        previous = @html_context
+        @html_context = false
+
+        yield
+      ensure
+        @html_context = previous
+      end
+
+      def render_template(format)
+        template_path = template_file_path(format)
+
+        File.exist?(template_path) ? ERB.new(File.read(template_path)).result(binding) : nil
+      end
+
+      def render_markdown_template
+        %w[md markdown].each do |ext|
+          template_path = template_file_path(ext)
+
+          return ERB.new(File.read(template_path)).result(binding) if File.exist?(template_path)
+        end
+
+        nil
+      end
+
+      def markdown_rendered
+        return unless Courrier::Markdown.available?
+
+        markdown_content = render_markdown_template || (respond_to?(:markdown, true) ? markdown : nil)
+
+        Courrier::Markdown.render(markdown_content) if markdown_content
+      end
+
+      def template_file_path(format)
+        class_path = self.class.name.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+
+        File.join(Courrier.configuration&.email_path, "#{class_path}.#{format}.erb")
+      end
+
+      def html_safe(value = nil, &block)
+        return in_safe_context { SafeString.new(block.call.to_s) } if block
+        return value.html_safe if value.is_a?(ContextValue)
+
+        SafeString.new(value.to_s)
+      end
+      alias_method :h, :html_safe
+
+      def respond_to_missing?(name, include_private = false) = true
+    end
+  end
+end

--- a/lib/courrier/safe_string.rb
+++ b/lib/courrier/safe_string.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Courrier
+  class SafeString
+    def initialize(string) = @string = string.to_s
+    def to_s = @string
+    def html_safe? = true
+  end
+end

--- a/test/courrier/email_test.rb
+++ b/test/courrier/email_test.rb
@@ -178,6 +178,151 @@ class Courrier::EmailTest < Minitest::Test
     end
   end
 
+  def test_subject_and_text_context_options_are_not_escaped
+    email = TestEmailWithContext.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      order_id: "R&D <5",
+      token: "abc"
+    )
+
+    assert_equal "Order R&D <5", email.subject
+    assert_equal "Test order R&D <5 with token abc", email.text
+  end
+
+  def test_html_context_options_are_escaped
+    email = TestEmailWithHtml.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      order_id: "<script>alert('xss')</script>"
+    )
+
+    assert_equal "<p>Order &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;</p>", email.options.html
+  end
+
+  def test_html_safe_attribute_is_not_escaped
+    email = TestEmailWithSafeAttribute.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      order_id: "<script>alert('xss')</script>"
+    )
+
+    assert_equal "<p><script>alert('xss')</script></p>", email.options.html
+  end
+
+  def test_h_attribute_is_not_escaped
+    email = TestEmailWithHAttribute.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      order_id: "<script>alert('xss')</script>"
+    )
+
+    assert_equal "<p><script>alert('xss')</script></p>", email.options.html
+  end
+
+  def test_html_safe_block_is_not_escaped
+    email = TestEmailWithSafeBlock.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      order_id: "<script>alert('xss')</script>"
+    )
+
+    assert_equal "<p>Order <script>alert('xss')</script></p>", email.options.html
+  end
+
+  def test_h_block_is_not_escaped
+    email = TestEmailWithHBlock.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      order_id: "<script>alert('xss')</script>"
+    )
+
+    assert_equal "<p>Order <script>alert('xss')</script></p>", email.options.html
+  end
+
+  def test_safe_string_is_not_escaped
+    email = TestEmailWithContext.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      order_id: Courrier::SafeString.new("<b>123</b>")
+    )
+
+    assert_equal "Order <b>123</b>", email.subject
+  end
+
+  def test_html_template_escapes_context_options
+    email_path = "tmp/test_emails"
+
+    FileUtils.mkdir_p(email_path)
+    File.write("#{email_path}/test_email_with_templates.html.erb", "<p>Hello <%= name %>!</p>")
+
+    Courrier.configure do |config|
+      config.email_path = email_path
+    end
+
+    email = TestEmailWithTemplates.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      name: "<script>alert('xss')</script>"
+    )
+
+    assert_equal "<p>Hello &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;!</p>", email.html
+
+    FileUtils.rm_rf(email_path)
+  end
+
+  def test_html_template_with_html_safe_attribute_is_not_escaped
+    email_path = "tmp/test_emails"
+
+    FileUtils.mkdir_p(email_path)
+    File.write("#{email_path}/test_email_with_templates.html.erb", "<p>Hello <%= html_safe(name) %>!</p>")
+
+    Courrier.configure do |config|
+      config.email_path = email_path
+    end
+
+    email = TestEmailWithTemplates.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      name: "<script>alert('xss')</script>"
+    )
+
+    assert_equal "<p>Hello <script>alert('xss')</script>!</p>", email.html
+
+    FileUtils.rm_rf(email_path)
+  end
+
+  def test_html_template_with_h_attribute_is_not_escaped
+    email_path = "tmp/test_emails"
+
+    FileUtils.mkdir_p(email_path)
+    File.write("#{email_path}/test_email_with_templates.html.erb", "<p>Hello <%= h(name) %>!</p>")
+
+    Courrier.configure do |config|
+      config.email_path = email_path
+    end
+
+    email = TestEmailWithTemplates.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      name: "<script>alert('xss')</script>"
+    )
+
+    assert_equal "<p>Hello <script>alert('xss')</script>!</p>", email.html
+
+    FileUtils.rm_rf(email_path)
+  end
+
+  def test_non_string_context_options_are_not_escaped
+    email = TestEmailWithContext.new(
+      to: "recipient@railsdesigner.com",
+      from: "devs@railsdesigner.com",
+      order_id: 123
+    )
+
+    assert_equal "Order 123", email.subject
+  end
+
   private
 
   def with_mocked_markdown

--- a/test/fixtures/test_email_with_safe_attributes.rb
+++ b/test/fixtures/test_email_with_safe_attributes.rb
@@ -1,0 +1,25 @@
+require "courrier/email"
+
+class TestEmailWithSafeAttribute < Courrier::Email
+  def subject = "Test"
+
+  def html = "<p>#{html_safe(order_id)}</p>"
+end
+
+class TestEmailWithHAttribute < Courrier::Email
+  def subject = "Test"
+
+  def html = "<p>#{h(order_id)}</p>"
+end
+
+class TestEmailWithSafeBlock < Courrier::Email
+  def subject = "Test"
+
+  def html = html_safe { "<p>Order #{order_id}</p>" }
+end
+
+class TestEmailWithHBlock < Courrier::Email
+  def subject = "Test"
+
+  def html = h { "<p>Order #{order_id}</p>" }
+end

--- a/test/fixtures/test_email_with_safe_html.rb
+++ b/test/fixtures/test_email_with_safe_html.rb
@@ -1,0 +1,7 @@
+require "courrier/email"
+
+class TestEmailWithHtml < Courrier::Email
+  def subject = "Test"
+
+  def html = "<p>Order #{order_id}</p>"
+end


### PR DESCRIPTION
Context options interpolated into HTML bodies were rendered verbatim, so values like `<script>alert('xss')</script>` could land in the email.  This typically is no issue: developer authors templates and most (all?) email clients strip `<script>` tags (but attributes like onerror and layout-breaking tags can still slip through).

So mitigate this altogether and only explicitly allow HTML with `h()` and `html_safe()`. Context options are now auto-escaped when rendered as HTML; use `h(value)`/`html_safe(value)` per attribute or `html_safe { … }` per block to opt out. Subject and plain-text bodies are unaffected.

This is a breaking change: HTML emails relying on raw interpolation must now wrap values in `h(value)`/`html_safe(value)`.