### PR TITLE
Add MailKite email provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Courrier supports these transactional email providers:
 - [Lettermint](https://lettermint.co)
 - [Loops](https://loops.so)
 - [Mailgun](https://mailgun.com)
+- [MailKite](https://mailkite.dev)
 - [MailPace](https://mailpace.com)
 - [Postmark](https://postmarkapp.com)
 - [Resend](https://resend.com)

--- a/lib/courrier/email/provider.rb
+++ b/lib/courrier/email/provider.rb
@@ -7,6 +7,7 @@ require "courrier/email/providers/lettermint"
 require "courrier/email/providers/logger"
 require "courrier/email/providers/loops"
 require "courrier/email/providers/mailgun"
+require "courrier/email/providers/mailkite"
 require "courrier/email/providers/mailjet"
 require "courrier/email/providers/mailpace"
 require "courrier/email/providers/postmark"
@@ -27,6 +28,7 @@ module Courrier
         lettermint: Courrier::Email::Providers::Lettermint,
         loops: Courrier::Email::Providers::Loops,
         mailgun: Courrier::Email::Providers::Mailgun,
+        mailkite: Courrier::Email::Providers::Mailkite,
         mailjet: Courrier::Email::Providers::Mailjet,
         mailpace: Courrier::Email::Providers::Mailpace,
         postmark: Courrier::Email::Providers::Postmark,

--- a/lib/courrier/email/providers/mailkite.rb
+++ b/lib/courrier/email/providers/mailkite.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Courrier
+  class Email
+    module Providers
+      class Mailkite < Base
+        ENDPOINT_URL = "https://api.mailkite.dev/v1/send"
+
+        def body
+          {
+            "from" => @options.from,
+            "to" => addresses(@options.to),
+            "cc" => addresses(@options.cc),
+            "bcc" => addresses(@options.bcc),
+            "replyTo" => @options.reply_to,
+            "subject" => @options.subject,
+            "text" => @options.text,
+            "html" => @options.html
+          }.compact
+        end
+
+        private
+
+        def default_headers
+          {
+            "Authorization" => "Bearer #{@api_key}"
+          }
+        end
+
+        def addresses(value)
+          list = value&.to_s&.split(",")&.map(&:strip)&.reject(&:empty?)
+
+          list&.empty? ? nil : list
+        end
+      end
+    end
+  end
+end

--- a/test/courrier/email/provider_test.rb
+++ b/test/courrier/email/provider_test.rb
@@ -52,6 +52,7 @@ class TestCourrierEmailProvider < Minitest::Test
       logger: Courrier::Email::Providers::Logger,
       loops: Courrier::Email::Providers::Loops,
       mailgun: Courrier::Email::Providers::Mailgun,
+      mailkite: Courrier::Email::Providers::Mailkite,
       mailjet: Courrier::Email::Providers::Mailjet,
       mailpace: Courrier::Email::Providers::Mailpace,
       postmark: Courrier::Email::Providers::Postmark,

--- a/test/courrier/email/providers/mailkite_test.rb
+++ b/test/courrier/email/providers/mailkite_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+module Courrier::Email::Providers
+  class MailkiteTest < Minitest::Test
+    def setup
+      email = TestEmail.new(
+        from: "devs@railsdesigner.com",
+        to: "first@example.com, second@example.com",
+        reply_to: "support@railsdesigner.com",
+        cc: "copy@example.com",
+        bcc: "archive@example.com"
+      )
+
+      @provider = Mailkite.new(api_key: "test_key", options: email.options)
+    end
+
+    def test_formats_transactional_email
+      assert_equal(
+        {
+          "from" => "devs@railsdesigner.com",
+          "to" => ["first@example.com", "second@example.com"],
+          "cc" => ["copy@example.com"],
+          "bcc" => ["archive@example.com"],
+          "replyTo" => "support@railsdesigner.com",
+          "subject" => "Test Subject",
+          "text" => "Test Body",
+          "html" => "<p>Test HTML Body</p>"
+        },
+        @provider.body
+      )
+    end
+
+    def test_omits_optional_recipients_when_absent
+      email = TestEmail.new(
+        from: "devs@railsdesigner.com",
+        to: "first@example.com"
+      )
+
+      provider = Mailkite.new(api_key: "test_key", options: email.options)
+
+      assert_equal(
+        {
+          "from" => "devs@railsdesigner.com",
+          "to" => ["first@example.com"],
+          "subject" => "Test Subject",
+          "text" => "Test Body",
+          "html" => "<p>Test HTML Body</p>"
+        },
+        provider.body
+      )
+    end
+
+    def test_authenticates_with_bearer_api_key
+      assert_equal({"Authorization" => "Bearer test_key"}, @provider.send(:default_headers))
+    end
+
+    def test_is_available_through_provider_registry
+      mock_provider = Minitest::Mock.new
+      mock_provider.expect(:deliver, nil)
+
+      Mailkite.stub :new, mock_provider do
+        Courrier::Email::Provider.new(
+          provider: "mailkite",
+          api_key: "test_key",
+          options: @provider.instance_variable_get(:@options)
+        ).deliver
+      end
+
+      mock_provider.verify
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds **MailKite** as a transactional email provider, backed by MailKite's
`POST https://api.mailkite.dev/v1/send` JSON API.

## What changed

- New `Courrier::Email::Providers::Mailkite` provider that maps the standard
  `from` / `to` / `cc` / `bcc` / `reply_to` / `subject` / `text` / `html`
  fields to the MailKite send API, authenticating with a Bearer API key.
- Comma-separated recipients are split into arrays (`to`, `cc`, `bcc`), which
  is what the MailKite API accepts (`replyTo` stays a single string).
- Registered the provider in the `Courrier::Email::Provider` registry.
- Added provider tests (body formatting, optional-recipient omission, auth
  header, registry availability) and updated the registry coverage test.
- Documented MailKite in the README provider list.

## Usage

```ruby
Courrier.configure do |config|
  config.email = {
    provider: "mailkite",
    api_key: "mk_live_..."
  }

  config.from = "devs@example.com"
end

OrderEmail.deliver to: "recipient@example.com"
```

## Verification

`rake` (test + standard) passes: 104 runs, 192 assertions, 0 failures.